### PR TITLE
Null-safety for ship.getShield().getInnerColor() to prevent hard crash

### DIFF
--- a/src/shipmastery/mastery/impl/combat/shipsystems/HEFShieldEfficiency.java
+++ b/src/shipmastery/mastery/impl/combat/shipsystems/HEFShieldEfficiency.java
@@ -39,7 +39,9 @@ public class HEFShieldEfficiency extends ShipSystemEffect {
             this.ship = ship;
             this.strength = strength;
             this.id = id;
-            originalColor = ship.getShield().getInnerColor();
+            originalColor = (ship.getShield() != null) // may be null on phase ships, station modules, modded ships, etc.
+                    ? ship.getShield().getInnerColor()
+                    : Color.WHITE;
         }
 
         @Override


### PR DESCRIPTION
# Noticed a small issue causing a crash.
Turns out a ship from "What we left behind" has the High Energy Focus System but no shields on some submodules, this causes a null reference and a hard crash.
This is a quick fix just defaulting the null issue